### PR TITLE
output DNSME API request ID with errors

### DIFF
--- a/api.go
+++ b/api.go
@@ -128,17 +128,19 @@ func decodeBody(resp *http.Response, out interface{}) error {
 // checkResp wraps http.Client.Do() and verifies that the
 // request was successful. A non-200 request returns an error
 // formatted to included any validation problems or otherwise
-func checkResp(resp *http.Response, err error) (*http.Response, error) {
+func checkResp(resp *http.Response, err error) (*http.Response, error, string) {
 	// If the err is already there, there was an error higher
 	// up the chain, so just return that
 	if err != nil {
-		return resp, err
+		return resp, err, "N/A"
 	}
 
+	reqid := resp.Header.Get("x-dnsme-requestId")
+
 	if resp.StatusCode/100 == 2 {
-		return resp, nil
+		return resp, nil, reqid
 	} else if resp.StatusCode == 404 {
-		return nil, fmt.Errorf("Not found")
+		return nil, fmt.Errorf("Not found"), reqid
 	}
-	return nil, fmt.Errorf("API Error: %s", resp.Status)
+	return nil, fmt.Errorf("API Error: %s", resp.Status), reqid
 }

--- a/record.go
+++ b/record.go
@@ -83,9 +83,9 @@ func (c *Client) CreateRecord(domainID string, cr map[string]interface{}) (strin
 		return "", fmt.Errorf("Error from NewRequest: %s", err)
 	}
 
-	resp, err := checkResp(c.HTTP.Do(req))
+	resp, err, reqid := checkResp(c.HTTP.Do(req))
 	if err != nil {
-		return "", fmt.Errorf("Error creating record: %s", err)
+		return "", fmt.Errorf("Error creating record: %s\n\tRequestID %s", err, reqid)
 	}
 
 	record := new(Record)
@@ -109,9 +109,9 @@ func (c *Client) ReadRecord(domainID string, recordID string) (*Record, error) {
 		return nil, err
 	}
 
-	resp, err := checkResp(c.HTTP.Do(req))
+	resp, err, reqid := checkResp(c.HTTP.Do(req))
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving record: %s", err)
+		return nil, fmt.Errorf("Error retrieving record: %s\n\tRequestID %s", err, reqid)
 	}
 
 	dataResp := DataResponse{}
@@ -139,6 +139,8 @@ func (c *Client) ReadRecord(domainID string, recordID string) (*Record, error) {
 // returns an error if it fails.
 func (c *Client) UpdateRecord(domainID string, recordID string, cr map[string]interface{}) (string, error) {
 
+    var reqid string
+
 	current, err := c.ReadRecord(domainID, recordID)
 	if err != nil {
 		return "", err
@@ -161,9 +163,9 @@ func (c *Client) UpdateRecord(domainID string, recordID string, cr map[string]in
 		return "", err
 	}
 
-	_, err = checkResp(c.HTTP.Do(req))
+	_, err, reqid = checkResp(c.HTTP.Do(req))
 	if err != nil {
-		return "", fmt.Errorf("Error updating record: %s", err)
+		return "", fmt.Errorf("Error updating record: %s\n\tRequestID %s", err, reqid)
 	}
 
 	// The request was successful
@@ -174,6 +176,7 @@ func (c *Client) UpdateRecord(domainID string, recordID string, cr map[string]in
 // returns an error if it fails. If no error is returned,
 // the Record was succesfully destroyed.
 func (c *Client) DeleteRecord(domainID string, recordID string) error {
+	var reqid string
 	body := bytes.NewBuffer(nil)
 	path := destroy.endpoint(domainID, recordID)
 	req, err := c.NewRequest("DELETE", path, body, "")
@@ -181,9 +184,9 @@ func (c *Client) DeleteRecord(domainID string, recordID string) error {
 		return err
 	}
 
-	_, err = checkResp(c.HTTP.Do(req))
+	_, err, reqid = checkResp(c.HTTP.Do(req))
 	if err != nil {
-		return fmt.Errorf("Unable to find record %s", recordID)
+		return fmt.Errorf("Unable to find record %s\n\tRequestID %s", recordID, reqid)
 	}
 
 	// The request was successful


### PR DESCRIPTION
Extract DNSME API request ID from response headers and include it in error outputs.
