### PR TITLE
Don't use third party gocheck mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.3
 
 install:
-- go get github.com/motain/gocheck
+- go get gopkg.in/check.v1
 - go get github.com/soniah/dnsmadeeasy
 
 script:

--- a/record_test.go
+++ b/record_test.go
@@ -2,8 +2,8 @@ package dnsmadeeasy
 
 import (
 	"fmt"
-	. "github.com/motain/gocheck"
 	"github.com/soniah/dnsmadeeasy/testutil"
+	. "gopkg.in/check.v1"
 	"testing"
 )
 


### PR DESCRIPTION
Just a simple (and hopefully unobjectionable) change--I noticed the import for gocheck seemed a bit weird and that there seems to be [a different and preferred](https://github.com/go-check/check/blob/v1/README.md)(?) way to import gocheck.

I only noticed it because I'm poking around and trying to get more API coverage so we get add more resources in Terraform.

Thanks :smile: 
