### PR TITLE
Fix Record merging for Record updates

### DIFF
--- a/record.go
+++ b/record.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/imdario/mergo"
+	"github.com/mitchellh/mapstructure"
 	"strconv"
 )
 
@@ -16,28 +16,28 @@ type DataResponse struct {
 
 // Record is used to represent a retrieved Record.
 type Record struct {
-	Name         string `json:"name"`
-	Value        string `json:"value"`
+	Name         string `json:"name" mapstructure:"name"`
+	Value        string `json:"value" mapstructure:"value"`
 	RecordID     int64  `json:"id"`
-	Type         string `json:"type"`
+	Type         string `json:"type" mapstructure:"type"`
 	Source       int64  `json:"source"`
 	SourceID     int64  `json:"sourceId"`
 	DynamicDNS   bool   `json:"dynamicDns"`
 	Password     string `json:"password"`
-	TTL          int64  `json:"ttl"`
+	TTL          int64  `json:"ttl" mapstructure:"ttl"`
 	Monitor      bool   `json:"monitor"`
 	Failover     bool   `json:"failover"`
 	Failed       bool   `json:"failed"`
 	GtdLocation  string `json:"gtdLocation"`
-	Description  string `json:"description"`
-	Keywords     string `json:"keywords"`
-	Title        string `json:"title"`
-	HardLink     bool   `json:"hardLink"`
-	MXLevel      int64  `json:"mxLevel"`
-	Weight       int64  `json:"weight"`
-	Priority     int64  `json:"priority"`
-	Port         int64  `json:"port"`
-	RedirectType string `json:"redirectType"`
+	Description  string `json:"description" mapstructure:"description"`
+	Keywords     string `json:"keywords" mapstructure:"keywords"`
+	Title        string `json:"title" mapstructure:"title"`
+	HardLink     bool   `json:"hardLink" mapstructure:"hardLink"`
+	MXLevel      int64  `json:"mxLevel" mapstructure:"mxLevel"`
+	Weight       int64  `json:"weight" mapstructure:"weight"`
+	Priority     int64  `json:"priority" mapstructure:"priority"`
+	Port         int64  `json:"port" mapstructure:"port"`
+	RedirectType string `json:"redirectType" mapstructure:"redirectType"`
 }
 
 // StringRecordID returns the record id as a string.
@@ -144,7 +144,7 @@ func (c *Client) UpdateRecord(domainID string, recordID string, cr map[string]in
 		return "", err
 	}
 
-	err = mergo.Map(current, cr)
+	err = mapstructure.Decode(cr, current)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
I had a go at fixing `Record` merging on Terraform updates. Turns out the following are true:
1. We can't just use Mergo's `MapWithOverwrite` because it doesn't deal with non-CamelCase field names. For example it would fail to successfully map `map[string]interface{}{"ttl": int64(1)}` onto `struct { TTL int64 }`, it would however be okay if the field were named `Ttl`.
2. It's not possible to just rename `TTL` to `Ttl` as this breaks upstream consumers (in this case Terraform).

Anyway, I just ended up using one of Mitchell Hashimoto's libraries (so I figure it should be okay to use in Terraform :wink:) to merge `map[string]interface{}`s onto `struct`s.

I appreciate the tests are in a bit of weird state with the test I added new-ing up its own client and HTTP test server. However, I'll spend some time refactoring them to be more consistent. Basically I'm hoping to move over to using `net/http/httptest` rather than custom one currently used. That's of course assuming this PR seems reasonable.

The stub data I added to test the merging is also somewhat weird because it returns an effectively impossible response from DME's API that is some sort of combination of an `A`, `MX`, `SRV` and `HTTPRED` record. I figure this was the easiest/clearest way to test all the possible fields that can be merged and thought it wasn't too unreasonable given this provider currently always decodes the JSON response onto the same object anyway.

This should resolve issue #3.
