### PR TITLE
Added power support for the travis.yml file with ppc64le. and update go versions  for package: dnsmadeeasy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: go
-
+arch:
+- amd64
+- ppc64le
 go:
-- 1.1
-- 1.2
-- 1.3
+- 1.13
+- 1.14
+- 1.15
 
 install:
 - go get github.com/motain/gocheck


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.

 updated the go version go:1.13, 1.14 and 1.15